### PR TITLE
[BK-92] [feat] 감상문 상세 페이지 삭제, 공개여부 변환 및 세부 로직 구현

### DIFF
--- a/frontend/src/pages/BookReviewDetail.jsx
+++ b/frontend/src/pages/BookReviewDetail.jsx
@@ -29,6 +29,17 @@ export default function BookReviewDetail() {
     fetchBookReviewDetail();
   }, [reviewId]);
 
+  async function handleDeleteReview() {
+    try {
+      alert('정말 삭제하시겠습니까?');
+      const response = await reviewApi.deleteReview(reviewId);
+      alert('감상문 삭제 성공');
+      navigate('/');
+    } catch (e) {
+      console.error('감상문 삭제 실패');
+    }
+  }
+
   async function handleApprovalStatus() {
     try {
       const response = await reviewApi.patchReviewPrivateStatus(reviewId);
@@ -81,7 +92,7 @@ export default function BookReviewDetail() {
                     <div>수정</div>
                   </Link>
                   <hr />
-                  <div>삭제</div>
+                  <div onClick={handleDeleteReview}>삭제</div>
                   <hr />
                   <div onClick={handleApprovalStatus}>
                     {reviewDetail?.approved ? '비공개' : '공개'}

--- a/frontend/src/pages/BookReviewDetail.jsx
+++ b/frontend/src/pages/BookReviewDetail.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import styles from '../styles/BookReviewDetail.module.css';
 import reviewApi from '../api/reviewApi';
 import { useSelector } from 'react-redux';
+import dayjs from 'dayjs';
 
 export default function BookReviewDetail() {
   const { reviewId } = useParams();
@@ -11,6 +12,7 @@ export default function BookReviewDetail() {
 
   const [reviewDetail, setReviewDetail] = useState({});
   const [isAuthor, setIsAuthor] = useState(false);
+  const [clickManageButton, setClickManageButton] = useState(false);
 
   useEffect(() => {
     async function fetchBookReviewDetail() {
@@ -53,6 +55,10 @@ export default function BookReviewDetail() {
     }
   }
 
+  function handleClickManageButton() {
+    setClickManageButton(!clickManageButton);
+  }
+
   if (!reviewDetail.approved && !isAuthor) {
     return <div>비공개글입니다</div>;
   }
@@ -82,23 +88,25 @@ export default function BookReviewDetail() {
             <h1>Review by "{reviewDetail?.username}"</h1>
           </Link>
           <div className={styles.postUserDetail}>
-            <div>{reviewDetail?.createdAt}</div>
+            <div>{reviewDetail?.createdAt.slice(0, 10)}</div>
             {isAuthor && reviewDetail?.approved ? <div>🔓</div> : <div>🔒</div>}
             {isAuthor && (
-              <>
-                <div>•••</div>
-                <div className={styles.manageReviewSection}>
-                  <Link to={`/reviews/modify/${reviewId}`}>
-                    <div>수정</div>
-                  </Link>
-                  <hr />
-                  <div onClick={handleDeleteReview}>삭제</div>
-                  <hr />
-                  <div onClick={handleApprovalStatus}>
-                    {reviewDetail?.approved ? '비공개' : '공개'}
+              <div>
+                <div onClick={handleClickManageButton}>•••</div>
+                {clickManageButton && (
+                  <div className={styles.manageReviewSection}>
+                    <Link to={`/reviews/modify/${reviewId}`}>
+                      <div>수정</div>
+                    </Link>
+                    <hr />
+                    <div onClick={handleDeleteReview}>삭제</div>
+                    <hr />
+                    <div onClick={handleApprovalStatus}>
+                      {reviewDetail?.approved ? '비공개' : '공개'}
+                    </div>
                   </div>
-                </div>
-              </>
+                )}
+              </div>
             )}
           </div>
         </section>

--- a/frontend/src/pages/BookReviewDetail.jsx
+++ b/frontend/src/pages/BookReviewDetail.jsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useState } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import styles from '../styles/BookReviewDetail.module.css';
 import reviewApi from '../api/reviewApi';
+import { useSelector } from 'react-redux';
 
 export default function BookReviewDetail() {
   const { reviewId } = useParams();
+  const navigate = useNavigate();
+  const auth = useSelector((state) => state.auth.username);
 
   const [reviewDetail, setReviewDetail] = useState({});
+  const [isAuthor, setIsAuthor] = useState(false);
 
   useEffect(() => {
     async function fetchBookReviewDetail() {
@@ -14,6 +18,10 @@ export default function BookReviewDetail() {
         const response = await reviewApi.getReviewDetail(reviewId);
         const data = response.data;
         setReviewDetail(data);
+
+        if (data.username == auth) {
+          setIsAuthor(true);
+        }
       } catch (e) {
         console.error('감상문 조회에 실패했습니다.');
       }
@@ -21,11 +29,22 @@ export default function BookReviewDetail() {
     fetchBookReviewDetail();
   }, [reviewId]);
 
-  /* 
-  TODO
-  - 메인으로 이동 시 책 제목으로 감상문 검색되게 하기
-  - 감상문 관리버튼은 작성자만 사용 가능하게  
-  */
+  async function handleApprovalStatus() {
+    try {
+      const response = await reviewApi.patchReviewPrivateStatus(reviewId);
+      const data = response.data;
+
+      setReviewDetail((prev) => ({ ...prev, ...data }));
+
+      alert('감상문 공개범위를 변경했습니다.');
+    } catch {
+      console.error('감상문 공개범위 변경 실패');
+    }
+  }
+
+  if (!reviewDetail.approved && !isAuthor) {
+    return <div>비공개글입니다</div>;
+  }
 
   return (
     <main className={styles.bookReviewDetailContainer}>
@@ -38,12 +57,11 @@ export default function BookReviewDetail() {
           </div>
         </div>
         <div className={styles.bookDetailSection}>
-          <Link to={`?title=${reviewDetail?.items?.title}`}>
+          <Link to={'/'} state={{ title: reviewDetail?.items?.title }}>
             <h3>{reviewDetail?.items?.title}</h3>
           </Link>
-          <div>
-            {reviewDetail?.items?.author} | {reviewDetail?.items?.publisher}
-          </div>
+          <div>{reviewDetail?.items?.author}</div>
+          <div>{reviewDetail?.items?.publisher}</div>
         </div>
       </section>
       <div className={styles.dividedLine}></div>
@@ -54,17 +72,23 @@ export default function BookReviewDetail() {
           </Link>
           <div className={styles.postUserDetail}>
             <div>{reviewDetail?.createdAt}</div>
-            {reviewDetail?.approved ? <div>🔒</div> : <div>🔓</div>}
-            <div>•••</div>
-            <div className={styles.manageReviewSection}>
-              <Link to={`/reviews/modify/${reviewId}`}>
-                <div>수정</div>
-              </Link>
-              <hr />
-              <div>삭제</div>
-              <hr />
-              <div>비공개 | 공개</div>
-            </div>
+            {isAuthor && reviewDetail?.approved ? <div>🔓</div> : <div>🔒</div>}
+            {isAuthor && (
+              <>
+                <div>•••</div>
+                <div className={styles.manageReviewSection}>
+                  <Link to={`/reviews/modify/${reviewId}`}>
+                    <div>수정</div>
+                  </Link>
+                  <hr />
+                  <div>삭제</div>
+                  <hr />
+                  <div onClick={handleApprovalStatus}>
+                    {reviewDetail?.approved ? '비공개' : '공개'}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
         </section>
         <hr />

--- a/frontend/src/styles/BookReviewDetail.module.css
+++ b/frontend/src/styles/BookReviewDetail.module.css
@@ -105,6 +105,10 @@ a {
   margin: 0;
   padding: 1rem;
   text-align: center;
+  position: absolute;
+  z-index: 10;
+  background: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .manageReviewSection > hr {


### PR DESCRIPTION
## 🔍 관련 Jira 이슈

- BK-92

## 📝 변경 사항

<!-- 이번 PR에서 작업한 내용을 명확히 기술해주세요 -->

- 감상문 공개범위에 따른 접근 제한
- 공개범위 변경 기능 구현
- 감상문 삭제 기능 구현
- 감상문 관리 모달창 구현

## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트

## 📌 참고 사항

1. 감상문이 삭제되면 DB에서는 지워지나 406 에러 발생 
- BE 감상문 삭제 담당자와 확인 필요

2. 감상문 상세페이지에서 책 제목 클릭 시 메인 화면으로 이동 
- 이때, 검색창에 제목이 바로 입력되면 좋을 것 같음
- 우선 Link 태그를 통해 state(제목) 전달해놓음

3. 유저가 등록한 도서인 경우, 감상문 삭제 시 도서 데이터도 삭제해야 하는지 확인 필요

4. 감상문 상세 조회 시 인증된 도서 확인을 위해 응답값 변경이 필요할 것 같음 