### PR TITLE
[BK-110] [fix] 유저별 감상문 모음 페이지 응답데이터 변경

### DIFF
--- a/backend/src/main/java/org/example/book_report/controller/BookReviewController.java
+++ b/backend/src/main/java/org/example/book_report/controller/BookReviewController.java
@@ -106,10 +106,10 @@ public class BookReviewController {
 
     // 유저별 감상문 모음 조회
     @GetMapping("/userpage/{username}")
-    public ResponseEntity<ApiResponse<UserBookReviewsResponseDto>> getUserBookReviews(@PathVariable("username") String username, Pageable pageable) {
+    public ResponseEntity<ApiResponse<UserBookReviewsResponseDto>> getUserBookReviews(@PathVariable("username") String username, Pageable pageable, @AuthenticationPrincipal User user) {
         return ResponseEntity.ok(
                 ApiResponse.ok(
-                        bookReviewService.getUserBookReviews(username, pageable)
+                        bookReviewService.getUserBookReviews(username, pageable, user.getUsername())
                 )
         );
     }

--- a/backend/src/main/java/org/example/book_report/repository/BookReviewRepository.java
+++ b/backend/src/main/java/org/example/book_report/repository/BookReviewRepository.java
@@ -24,14 +24,15 @@ public interface BookReviewRepository extends JpaRepository<BookReview, Long> {
     Page<BookReview> getBookReviews(@Param("bookTitle") String bookTitle, Pageable pageable);
 
     @Query("""
-            SELECT br FROM BookReview br
-            JOIN FETCH br.image i
-            LEFT JOIN FETCH i.userImage ui
-            JOIN br.user u
-            WHERE u.username =:username
-            ORDER BY br.createdAt DESC
+                SELECT br FROM BookReview br
+                JOIN FETCH br.image i
+                LEFT JOIN FETCH i.userImage ui
+                JOIN br.user u
+                WHERE u.username = :username
+                  AND ( u.username=:loginedUsername OR br.approved = true)
+                ORDER BY br.createdAt DESC
             """)
-    Page<BookReview> getUserBookReviews(@Param("username") String username, Pageable pageable);
+    Page<BookReview> getUserBookReviews(@Param("username") String username, Pageable pageable, @Param("loginedUsername") String loginedUsername);
 
     @Query("""
             SELECT br FROM BookReview br

--- a/backend/src/main/java/org/example/book_report/service/BookReviewService.java
+++ b/backend/src/main/java/org/example/book_report/service/BookReviewService.java
@@ -106,8 +106,9 @@ public class BookReviewService {
     }
 
     // 유저별 감상문 모음 조회
-    public UserBookReviewsResponseDto getUserBookReviews(String username, Pageable pageable) {
-        Page<BookReview> bookReviews = bookReviewRepository.getUserBookReviews(username, pageable);
+    public UserBookReviewsResponseDto getUserBookReviews(String username, Pageable pageable, String loginedUsername) {
+        Page<BookReview> bookReviews = bookReviewRepository.getUserBookReviews(username, pageable, loginedUsername);
+
         return UserBookReviewsResponseDto.from(bookReviews);
     }
 }


### PR DESCRIPTION
# .github/pull_request_template.md

## 🔍 관련 Jira 이슈

- BK-110
- BK-94

## 📝 변경 사항

- 로그인한 유저와 페이지 유저가 같으면 모든 감상문을, 다르면 공개 감상문만 반환하도록 응답 데이터를 변경


## ✅ PR 체크리스트

- [x] 커밋 메시지에 Jira 이슈 번호 포함
- [ ] 관련 문서 업데이트 (필요한 경우)
- [x] Jira 이슈 상태 업데이트